### PR TITLE
Allows client to receive an account_id to send on requests headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,26 @@ Myfinance.configure do |m|
 end
 ```
 
+### Multiple accounts
+
+When an account has multiple accounts, an `ACCOUNT_ID` header is required for the requests. To instantiate a new client with an `ACCOUNT_ID` header:
+
+```ruby
+client = Myfinance.client("YOUR_TOKEN_HERE", ACCOUNT_ID) # where ACCOUNT_ID is the ID of the account
+```
+
+If you instantiate a new client without an `account_id` and the user has more than one account, the lib will raise a [`Myfinance::RequestError`](https://github.com/myfreecomm/myfinance-client-ruby/blob/master/lib/myfinance/response.rb#L33) error. The list of available accounts will be in the body of the object.
+
+```ruby
+begin
+  client.entities.find_all
+rescue Myfinance::RequestError => e
+  e.body # { "error" => "O cabeçalho da requisição não possui o atributo ACCOUNT_ID.", "accounts" => [{"account" => { "id" => 3, .. } }, { ... }] }
+  e.message # O cabeçalho da requisição não possui o atributo ACCOUNT_ID.
+  e.code # 422
+end
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/myfinance/client.rb
+++ b/lib/myfinance/client.rb
@@ -5,8 +5,8 @@ module Myfinance
   class Client
     attr_reader :http
 
-    def initialize(token)
-      @http = Http.new(token)
+    def initialize(token, account_id = nil)
+      @http = Http.new(token, account_id)
     end
 
     def authenticated?

--- a/lib/myfinance/http.rb
+++ b/lib/myfinance/http.rb
@@ -3,10 +3,11 @@ require "myfinance/response"
 
 module Myfinance
   class Http
-    attr_reader :token
+    attr_reader :token, :account_id
 
-    def initialize(token)
+    def initialize(token, account_id = nil)
       @token = token
+      @account_id = account_id
     end
 
     %w[get post delete put].each do |m|
@@ -22,7 +23,8 @@ module Myfinance
         method: method,
         token: token,
         url: "#{Myfinance.configuration.url}#{path}",
-        user_agent: Myfinance.configuration.user_agent
+        user_agent: Myfinance.configuration.user_agent,
+        account_id: account_id
       }))
 
       response = Response.new(request.run)

--- a/lib/myfinance/request.rb
+++ b/lib/myfinance/request.rb
@@ -35,8 +35,9 @@ module Myfinance
         "Accept"         => "application/json",
         "Content-Type"   => "application/json",
         "User-Agent"     => args[:user_agent],
-        "Authorization" => "Basic #{authorization_hash}"
-      }.merge(headers)
+        "Authorization"  => "Basic #{authorization_hash}",
+        "ACCOUNT_ID"     => args[:account_id]
+      }.merge(headers).delete_if { |_,v| v.nil? || v.to_s.empty? }
     end
 
     def body

--- a/lib/myfinance/response.rb
+++ b/lib/myfinance/response.rb
@@ -32,10 +32,14 @@ module Myfinance
     def error!
       raise RequestError.new(
         code:    code,
-        message: status_message,
-        body:    body
+        message: request_error_message,
+        body:    parsed_body
       )
     end
 
+    def request_error_message
+      return status_message if !status_message.nil? && status_message != ""
+      parsed_body["error"] || ""
+    end
   end
 end

--- a/spec/lib/myfinance/client_spec.rb
+++ b/spec/lib/myfinance/client_spec.rb
@@ -5,8 +5,15 @@ describe Myfinance::Client do
 
   describe "#initialize" do
     it "instantiates a new Myfinance::Http object" do
-      expect(Myfinance::Http).to receive(:new).with("abc")
+      expect(Myfinance::Http).to receive(:new).with("abc", nil)
       Myfinance::Client.new("abc")
+    end
+
+    context "when account_id is present" do
+      it "instantiates a new Myfinance::Http object" do
+        expect(Myfinance::Http).to receive(:new).with("abc", 123)
+        Myfinance::Client.new("abc", 123)
+      end
     end
   end
 

--- a/spec/lib/myfinance/http_spec.rb
+++ b/spec/lib/myfinance/http_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
 
 describe Myfinance::Http do
-  subject { Myfinance::Http.new('b552dd5a8598ca089b91c5e355a83b86e4696aefac9eaa05') }
+  let(:account_id) { 12 }
+  subject { Myfinance::Http.new('b552dd5a8598ca089b91c5e355a83b86e4696aefac9eaa05', account_id) }
 
   describe '#get' do
     let(:http_method) { :get }

--- a/spec/lib/myfinance/request_spec.rb
+++ b/spec/lib/myfinance/request_spec.rb
@@ -20,10 +20,37 @@ describe Myfinance::Request do
       subject.run
     end
 
-    it 'generates the base 64 of the user token' do
+    it "generates the base 64 of the user token" do
       allow_any_instance_of(Typhoeus::Request).to receive(:run)
       expect(Base64).to receive(:strict_encode64).with("my-auth-hash:X").and_call_original
       subject.run
+    end
+
+    context "when account_id is empty" do
+      subject { described_class.new({ method: 'post', params: {}, url: Myfinance.configuration.url, user_agent: 'My Test User-Agent', token: 'my-auth-hash', account_id: "" }) }
+
+      it "does not add ACCOUNT_ID on headers" do
+        expect(Typhoeus::Request).to receive(:new).with("https://sandbox.myfinance.com.br", { method: "post", params: {}, headers: { "Accept" => "application/json", "Content-Type" => "application/json", "User-Agent" => "My Test User-Agent", "Authorization" => "Basic bXktYXV0aC1oYXNoOlg=" }, accept_encoding: "gzip" }).and_return(double(run: true, response: true))
+        subject.run
+      end
+    end
+
+    context "when account_id is nil" do
+      subject { described_class.new({ method: 'post', params: {}, url: Myfinance.configuration.url, user_agent: 'My Test User-Agent', token: 'my-auth-hash', account_id: nil }) }
+
+      it "does not add ACCOUNT_ID on headers" do
+        expect(Typhoeus::Request).to receive(:new).with("https://sandbox.myfinance.com.br", { method: "post", params: {}, headers: { "Accept" => "application/json", "Content-Type" => "application/json", "User-Agent" => "My Test User-Agent", "Authorization" => "Basic bXktYXV0aC1oYXNoOlg=" }, accept_encoding: "gzip" }).and_return(double(run: true, response: true))
+        subject.run
+      end
+    end
+
+    context "when account_id is present" do
+      subject { described_class.new({ method: 'post', params: {}, url: Myfinance.configuration.url, user_agent: 'My Test User-Agent', token: 'my-auth-hash', account_id: 12 }) }
+
+      it "does not add ACCOUNT_ID on headers" do
+        expect(Typhoeus::Request).to receive(:new).with("https://sandbox.myfinance.com.br", { method: "post", params: {}, headers: { "Accept" => "application/json", "Content-Type" => "application/json", "User-Agent" => "My Test User-Agent", "Authorization" => "Basic bXktYXV0aC1oYXNoOlg=", "ACCOUNT_ID" => 12 }, accept_encoding: "gzip" }).and_return(double(run: true, response: true))
+        subject.run
+      end
     end
   end
 end

--- a/spec/lib/myfinance/resources/payable_account_spec.rb
+++ b/spec/lib/myfinance/resources/payable_account_spec.rb
@@ -66,7 +66,7 @@ describe Myfinance::Resources::PayableAccount do
       end
 
       it "adds information on request error object" do
-        expect(Myfinance::RequestError).to receive(:new).with(code: 422, message: "", body: "{\"competency_month\":[\"n\\u00e3o pode ser vazio\"],\"due_date\":[\"n\\u00e3o \\u00e9 uma data v\\u00e1lida\"]}").and_call_original
+        expect(Myfinance::RequestError).to receive(:new).with(code: 422, message: "", body: { "competency_month" => ["não pode ser vazio"], "due_date" => ["não é uma data válida"] }).and_call_original
         expect { subject }.to raise_error(Myfinance::RequestError)
       end
     end
@@ -79,7 +79,7 @@ describe Myfinance::Resources::PayableAccount do
       end
 
       it "adds information on request error object" do
-        expect(Myfinance::RequestError).to receive(:new).with(code: 403, message: "Forbidden", body: "{\"error\":\"Voc\\u00ea n\\u00e3o tem permiss\\u00e3o para acessar este recurso.\"}").and_call_original
+        expect(Myfinance::RequestError).to receive(:new).with(code: 403, message: "Forbidden", body: {"error" => "Você não tem permissão para acessar este recurso." }).and_call_original
         expect { subject }.to raise_error(Myfinance::RequestError)
       end
     end

--- a/spec/lib/myfinance/resources/receivable_account_spec.rb
+++ b/spec/lib/myfinance/resources/receivable_account_spec.rb
@@ -66,7 +66,7 @@ describe Myfinance::Resources::ReceivableAccount do
       end
 
       it "adds information on request error object" do
-        expect(Myfinance::RequestError).to receive(:new).with(code: 422, message: "", body: "{\"competency_month\":[\"n\\u00e3o pode ser vazio\"],\"due_date\":[\"n\\u00e3o \\u00e9 uma data v\\u00e1lida\"]}").and_call_original
+        expect(Myfinance::RequestError).to receive(:new).with(code: 422, message: "", body: { "competency_month" => ["não pode ser vazio"], "due_date" => ["não é uma data válida"] }).and_call_original
         expect { subject }.to raise_error(Myfinance::RequestError)
       end
     end
@@ -79,7 +79,7 @@ describe Myfinance::Resources::ReceivableAccount do
       end
 
       it "adds information on request error object" do
-        expect(Myfinance::RequestError).to receive(:new).with(code: 403, message: "Forbidden", body: "{\"error\":\"Voc\\u00ea n\\u00e3o tem permiss\\u00e3o para acessar este recurso.\"}").and_call_original
+        expect(Myfinance::RequestError).to receive(:new).with(code: 403, message: "Forbidden", body: { "error" => "Você não tem permissão para acessar este recurso." }).and_call_original
         expect { subject }.to raise_error(Myfinance::RequestError)
       end
     end

--- a/spec/support/shared_examples/http_request_methods.rb
+++ b/spec/support/shared_examples/http_request_methods.rb
@@ -1,7 +1,7 @@
 shared_examples 'available http request methods' do
   it "instantiates a new Request object" do
     VCR.use_cassette("client/#{http_method}/request") do
-      expect(Myfinance::Request).to receive(:new).and_call_original
+      expect(Myfinance::Request).to receive(:new).with({ body: params, method: http_method, token: "b552dd5a8598ca089b91c5e355a83b86e4696aefac9eaa05", url: "#{Myfinance.configuration.url}#{url}", user_agent: "Myfinance Ruby Client v0.2.0", account_id: account_id }).and_call_original
       subject.send(http_method, url, body: params)
     end
   end


### PR DESCRIPTION
When user has more than one account, it will raise an error. So, the client must receive an `account_id` to add it as a header in the request.
