### PR TITLE
Upgrades multi_json dependency to 1.11.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     myfinance (0.3.1)
-      multi_json (~> 1.9.0)
+      multi_json (~> 1.11)
       typhoeus (~> 0.7.1)
       virtus (~> 1.0.5)
 
@@ -27,13 +27,13 @@ GEM
     diff-lcs (1.2.5)
     docile (1.1.5)
     equalizer (0.0.11)
-    ethon (0.7.4)
+    ethon (0.8.0)
       ffi (>= 1.3.0)
     ffi (1.9.10)
     ice_nine (0.11.1)
     json (1.8.3)
     method_source (0.8.2)
-    multi_json (1.9.3)
+    multi_json (1.11.2)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)

--- a/myfinance.gemspec
+++ b/myfinance.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "typhoeus", "~> 0.7.1"
-  spec.add_dependency "multi_json", "~> 1.9.0"
+  spec.add_dependency "multi_json", "~> 1.11"
   spec.add_dependency "virtus", '~> 1.0.5'
 
   spec.add_development_dependency "bundler", "~> 1.10"


### PR DESCRIPTION
This PR upgrades the `multi_json` dependency to the most recent version. 

I've decided to add only the minor version and skip the patch in order to make it easier to upgrade in the future. :yellow_heart: 
