### PR TITLE
Make mime-type gem dependency more lax

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     myfinance (1.6.1)
-      mime-types (~> 2.99)
+      mime-types (>= 1.16, < 3.0)
       multi_json (~> 1.11)
       require_all (~> 1.4.0)
       typhoeus (~> 0.8)
@@ -30,14 +30,14 @@ GEM
     diff-lcs (1.3)
     docile (1.1.5)
     equalizer (0.0.11)
-    ethon (0.10.1)
+    ethon (0.11.0)
       ffi (>= 1.3.0)
-    ffi (1.9.18)
+    ffi (1.9.23)
     ice_nine (0.11.2)
     json (2.0.3)
     method_source (0.8.2)
     mime-types (2.99.3)
-    multi_json (1.12.1)
+    multi_json (1.13.1)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -97,4 +97,4 @@ DEPENDENCIES
   webmock (~> 1.9.3)
 
 BUNDLED WITH
-   1.15.3
+   1.16.1

--- a/myfinance.gemspec
+++ b/myfinance.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "typhoeus", "~> 0.8"
   spec.add_dependency "multi_json", "~> 1.11"
   spec.add_dependency "virtus", "~> 1.0.5"
-  spec.add_dependency "mime-types", "~> 2.99"
+  spec.add_dependency "mime-types", ">= 1.16", "< 3.0"
   spec.add_dependency "require_all", "~> 1.4.0"
 
   spec.add_development_dependency "bundler", "~> 1.10"


### PR DESCRIPTION
Rails 3 requires mime-type to be `~> 1.16`. If we want to keep supporting Rails 3, we have to make this dependency more lax.