### PR TITLE
Add headers attribute in RequestError object

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    myfinance (1.6.1)
+    myfinance (1.6.3)
       mime-types (>= 1.16, < 3.0)
       multi_json (~> 1.11)
       require_all (~> 1.4.0)

--- a/lib/myfinance/exception.rb
+++ b/lib/myfinance/exception.rb
@@ -1,11 +1,12 @@
 module Myfinance
   class Exception < StandardError
-    attr_accessor :code, :body
+    attr_accessor :code, :body, :headers
 
     def initialize(args = {})
       super(args[:message])
       @code     = args[:code]
       @body     = args[:body]
+      @headers  = args[:headers]
     end
   end
 end

--- a/lib/myfinance/response.rb
+++ b/lib/myfinance/response.rb
@@ -29,12 +29,12 @@ module Myfinance
     end
 
     def error!
-      error = RequestError.new(
+      raise RequestError.new(
         code:    code,
         message: request_error_message,
-        body:    parsed_body
+        body:    parsed_body,
+        headers: headers
       )
-      raise error
     end
 
     def request_error_message

--- a/spec/lib/myfinance/resources/attachment_spec.rb
+++ b/spec/lib/myfinance/resources/attachment_spec.rb
@@ -89,7 +89,7 @@ describe Myfinance::Resources::Attachment, vcr: true do
       end
 
       it "adds information on request error object" do
-        expect(Myfinance::RequestError).to receive(:new).with(code: 422, message: "Unprocessable Entity", body: { "attachment" => ["não pode ser vazio."] }).and_call_original
+        expect(Myfinance::RequestError).to receive(:new).with(code: 422, message: "Unprocessable Entity", body: { "attachment" => ["não pode ser vazio."] }, headers: instance_of(Typhoeus::Response::Header)).and_call_original
         expect { subject }.to raise_error(Myfinance::RequestError)
       end
     end
@@ -102,7 +102,7 @@ describe Myfinance::Resources::Attachment, vcr: true do
       end
 
       it "adds information on request error object" do
-        expect(Myfinance::RequestError).to receive(:new).with(code: 403, message: "Forbidden", body: {"error" => "Você não tem permissão para acessar este recurso." }).and_call_original
+        expect(Myfinance::RequestError).to receive(:new).with(code: 403, message: "Forbidden", body: {"error" => "Você não tem permissão para acessar este recurso." }, headers: instance_of(Typhoeus::Response::Header)).and_call_original
         expect { subject }.to raise_error(Myfinance::RequestError)
       end
     end

--- a/spec/lib/myfinance/resources/payable_account_spec.rb
+++ b/spec/lib/myfinance/resources/payable_account_spec.rb
@@ -144,7 +144,7 @@ describe Myfinance::Resources::PayableAccount do
 
       it "adds information on request error object" do
         body = { "competency_month" => ["não pode ser vazio"], "due_date" => ["não é uma data válida"] }
-        expect(request_error).to receive(:new).with(code: 422, message: "", body: body).and_call_original
+        expect(request_error).to receive(:new).with(code: 422, message: "", body: body, headers: instance_of(Typhoeus::Response::Header)).and_call_original
         expect { subject }.to raise_error(request_error)
       end
     end
@@ -158,7 +158,7 @@ describe Myfinance::Resources::PayableAccount do
 
       it "adds information on request error object" do
         body = {"error" => "Você não tem permissão para acessar este recurso." }
-        expect(request_error).to receive(:new).with(code: 403, message: "Forbidden", body: body).and_call_original
+        expect(request_error).to receive(:new).with(code: 403, message: "Forbidden", body: body, headers: instance_of(Typhoeus::Response::Header)).and_call_original
         expect { subject }.to raise_error(request_error)
       end
     end

--- a/spec/lib/myfinance/resources/receivable_account_spec.rb
+++ b/spec/lib/myfinance/resources/receivable_account_spec.rb
@@ -11,7 +11,7 @@ describe Myfinance::Resources::ReceivableAccount do
     before :each do
       subject.build
     end
-    
+
     context "with pagination" do
       subject { client.receivable_accounts.find_all(entity_id, page) }
 
@@ -145,7 +145,7 @@ describe Myfinance::Resources::ReceivableAccount do
 
       it "adds information on request error object" do
         body = { "competency_month" => ["não pode ser vazio"], "due_date" => ["não é uma data válida"] }
-        expect(request_error).to receive(:new).with(code: 422, message: "", body: body).and_call_original
+        expect(request_error).to receive(:new).with(code: 422, message: "", body: body, headers: instance_of(Typhoeus::Response::Header)).and_call_original
         expect { subject }.to raise_error(request_error)
       end
     end
@@ -159,7 +159,7 @@ describe Myfinance::Resources::ReceivableAccount do
 
       it "adds information on request error object" do
         body = { "error" => "Você não tem permissão para acessar este recurso." }
-        expect(request_error).to receive(:new).with(code: 403, message: "Forbidden", body: body).and_call_original
+        expect(request_error).to receive(:new).with(code: 403, message: "Forbidden", body: body, headers: instance_of(Typhoeus::Response::Header)).and_call_original
         expect { subject }.to raise_error(request_error)
       end
     end

--- a/spec/lib/myfinance/response_spec.rb
+++ b/spec/lib/myfinance/response_spec.rb
@@ -29,7 +29,20 @@ describe Myfinance::Response do
     end
 
     context 'when not success neither timeout' do
-      let(:response) { double(success?: false, timed_out?: false, code: 301, status_message: 'Moved Permanently', body: '') }
+      let(:headers) do
+        {
+          "Date" => "Tue, 17 Apr 2018 15:47:10 GMT", "Expires" => "-1",
+          "Cache-Control"=>"private, max-age=0"
+        }
+      end
+
+      let(:response) do
+        double({
+          success?: false, timed_out?: false, code: 301,
+          status_message: 'Moved Permanently', body: '',
+          headers: headers
+        })
+      end
 
       it 'raises RequestError' do
         expect { subject.resolve! }.to raise_error do |error|
@@ -37,12 +50,13 @@ describe Myfinance::Response do
           expect(error.code).to eq(301)
           expect(error.message).to eq("Moved Permanently")
           expect(error.body).to eq({})
+          expect(error.headers).to eq(headers)
         end
       end
 
       context "when status_message is empty" do
         context "when body has an 'error' key" do
-          let(:response) { double(success?: false, timed_out?: false, code: 301, status_message: '', body: '{"error": "My custom error message"}') }
+          let(:response) { double(success?: false, timed_out?: false, code: 301, status_message: '', body: '{"error": "My custom error message"}', headers: {}) }
 
           it "raises RequestError with custom message" do
             expect { subject.resolve! }.to raise_error do |error|
@@ -55,7 +69,7 @@ describe Myfinance::Response do
         end
 
         context "when body has an 'error' key" do
-          let(:response) { double(success?: false, timed_out?: false, code: 301, status_message: '', body: '') }
+          let(:response) { double(success?: false, timed_out?: false, code: 301, status_message: '', body: '', headers: {}) }
 
           it "raises RequestError with empty message" do
             expect { subject.resolve! }.to raise_error do |error|


### PR DESCRIPTION
Includes response headers when any exception raises in the ruby client.

This way, we could fetch the `X-RateLimit-Reset` headers when response is a `429` HTTP code.